### PR TITLE
DAS-1383 - Deployment GitHub Workflow

### DIFF
--- a/.github/workflows/deploy_docker_image.yml
+++ b/.github/workflows/deploy_docker_image.yml
@@ -1,0 +1,85 @@
+name: Deploy Harmony GDAL Adapter Docker image
+
+on:
+  push:
+    branches: [ main ]
+
+env:
+  IMAGE_NAME: ${{ github.repository }}
+  REGISTRY: ghcr.io
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ 3.8 ]
+
+    steps:
+      - name: Checkout harmony-gdal-adapter repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build test image
+        run: ./bin/build-test
+
+      - name: Run test image
+        run: ./bin/run-test
+
+      - name: Archive test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: Test results for Python ${{ matrix.python-version }}
+          path: test-reports/
+
+      - name: Archive coverage report
+        uses: actions/upload-artifact@v2
+        with:
+          name: Coverage report for Python ${{ matrix.python-version }}
+          path: coverage/*
+
+  build_and_deploy_image:
+    needs: run_tests
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout harmony-gdal-adapter repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+
+      - name: Extract semantic version number
+        run: echo "semantic_version=$(cat version.txt)" >> $GITHUB_ENV
+
+      - name: Log-in to ghcr.io registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add tags to the Docker image
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ env.semantic_version }}
+
+      - name: Push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/service.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,9 +1,9 @@
 name: Run Python unit tests
+
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
+
 jobs:
   build_and_test:
     runs-on: ubuntu-20.04

--- a/docker/service.Dockerfile
+++ b/docker/service.Dockerfile
@@ -26,5 +26,5 @@ RUN pip install -r requirements.txt
 # Copy service code into image
 COPY gdal_subsetter gdal_subsetter
 
-# Set entrypoint to run test script.
-ENTRYPOINT ["/home/tests/run_tests.sh"]
+# Set entrypoint to invoke service
+ENTRYPOINT ["python3", "-m", "gdal_subsetter"]


### PR DESCRIPTION
This PR adds a new workflow that _should_ deploy our Docker image to ghcr.io. It takes inspiration from PO.DAAC and the L2 Subsetter example supplied by @frankinspace.

I also spotted that the entry point in `service.Dockerfile` was incorrect. That was running the tests rather than invoking the service. I've updated it to copy the entry point from the [Dockerfile](https://github.com/asfadmin/asf-harmony-gdal/blob/dev/Dockerfile#L17) in the ASF repository (this also matches what the Harmony team have in their CI/CD repository).