### PR TITLE
DAS-1527 - Ensure service images are only pulished when version.txt is updated.

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -1,8 +1,9 @@
-name: Deploy Harmony GDAL Adapter Docker image
+name: Publish Harmony GDAL Adapter Docker image
 
 on:
   push:
     branches: [ main ]
+    paths: version.txt
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -45,7 +46,7 @@ jobs:
           name: Coverage report for Python ${{ matrix.python-version }}
           path: coverage/*
 
-  build_and_deploy_image:
+  build_and_publish_image:
     needs: run_tests
     runs-on: ubuntu-20.04
     strategy:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,23 @@
-# harmony-gdal-adapter (HGA)
+# harmony GDAL Adapter (HGA)
 
 ![](https://data-services-github-badges.s3.amazonaws.com/cov.svg?dummy=true)
 
-A Harmony (https://harmony.earthdata.nasa.gov/) backend service that transforms input images using GDAL.
+A Harmony (https://harmony.earthdata.nasa.gov/) backend service that transforms
+input images using GDAL.
 
-The harmony-gdal-adapter is deployed to [ghcr.io](https://github.com/nasa/harmony-gdal-adapter/pkgs/container/harmony-gdal-adapter) GitHub's Container registry.
+HGA is published to [ghcr.io](https://github.com/nasa/harmony-gdal-adapter/pkgs/container/harmony-gdal-adapter)
+GitHub's Container registry.
 
-The harmony-gdal-adapter is invoked by [harmony](https://github.com/nasa/harmony) when the harmony server is configured, via harmony's [service.yml](https://github.com/nasa/harmony/blob/main/config/services.yml) or by UMM-S/C associations in CMR, to handle an incoming request for the collection. You can see examples of requests that harmony dispatches to the harmony-gdal-adapter by examining the [regression test notebook for hga](https://github.com/nasa/harmony-regression-tests/blob/main/test/hga/HGA_regression.ipynb).
+HGA is invoked by [harmony](https://github.com/nasa/harmony)
+when the harmony server is configured, via Harmony's [service.yml](https://github.com/nasa/harmony/blob/main/config/services.yml)
+or by UMM-S/C associations in CMR, to handle an incoming request for the
+collection. You can see examples of requests that harmony dispatches to the
+harmony-gdal-adapter by examining the [regression test notebook for hga](https://github.com/nasa/harmony-regression-tests/blob/main/test/hga/HGA_regression.ipynb).
 
 
 ## Test with Docker
 
-### Build harmony-gdal-adapter image
+### Build HGA image
 ```bash
 bin/build-image
 ```
@@ -27,7 +33,8 @@ Creates the `nasa/harmony-gdal-adapter-test` test image.
 ```bash
 bin/run-test
 ```
-The `run-test` script mounts `test-reports` and `coverage` directories and run the test script `tests/run_tests.sh` inside of a docker test container.
+The `run-test` script mounts `test-reports` and `coverage` directories and run
+the test script `tests/run_tests.sh` inside of a Docker test container.
 
 
 ## Test Locally
@@ -162,9 +169,11 @@ access to the HGA repository.
 ### Semantic versioning:
 
 When making changes to the HGA service code, it is important to make updates to
-`version.txt` and `CHANGE.md`. Every time code is merged to the `main` branch,
-a Docker image is published to [ghcr.io](https://github.com/nasa/harmony-gdal-adapter/pkgs/container/harmony-gdal-adapter). The semantic version number listed in `version.txt` must
-be iterated to avoid overwriting an existing Docker image.
+`version.txt` and `CHANGE.md`. Every time code is merged to the `main` branch
+and the merged commits contain changes to `version.txt`, a Docker image is
+published to [ghcr.io](https://github.com/nasa/harmony-gdal-adapter/pkgs/container/harmony-gdal-adapter).
+By only triggering image publication when `version.txt` is incremented, the
+existing Docker images for HGA will not be overwritten.
 
 When writing or updating service code, please also update the existing test
 suite with unit tests to ensure the new functionality performs as expected, and

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# harmony GDAL Adapter (HGA)
+# Harmony GDAL Adapter (HGA)
 
 ![](https://data-services-github-badges.s3.amazonaws.com/cov.svg?dummy=true)
 


### PR DESCRIPTION
## Description

This PR updates the HGA CI/CD workflow that publishes Docker images to ghcr.io so that two conditions must be met:

* The publication will only occur when changes occur on the `main` branch (e.g., merging a PR). This was already in place.
* The new commits on the `main` branch must also have changes to the `version.txt` file.

This change helps ensure that we do not overwrite images that are already published to ghcr.io.

I've also updated the README to describe the updated process. Lastly, I followed the suggestion from Frank to make it clearer that this isn't a deployment, rather we are publishing the images. With that in mind, I renamed the workflow for clarity.

## Jira Issue ID

DAS-1527

## Local Test Steps

This PR cannot be tested locally as it is part of the CI/CD for this repository. (I did create a small personal repo, where I tested these rules to ensure they act as an "AND" rather than an "OR", and things looked good)

## PR Acceptance Checklist
* [x] Jira ticket acceptance criteria met.
* ~[ ] `version.txt` and `CHANGE.md` updated if any service code is changed.~
* ~[ ] Tests added/updated and passing.~
* [x] Documentation updated (if needed).
