### PR TITLE
Update Python action versions to use Node.js 16.

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout harmony-gdal-adapter repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           lfs: true
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -35,13 +35,13 @@ jobs:
         run: ./bin/run-test
 
       - name: Archive test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Test results for Python ${{ matrix.python-version }}
           path: test-reports/
 
       - name: Archive coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Coverage report for Python ${{ matrix.python-version }}
           path: coverage/*
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout harmony-gdal-adapter repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           lfs: true
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout harmony-gdal-adapter repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           lfs: true
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -30,13 +30,13 @@ jobs:
         run: ./bin/run-test
 
       - name: Archive test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Test results for Python ${{ matrix.python-version }}
           path: test-reports/
 
       - name: Archive coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Coverage report for Python ${{ matrix.python-version }}
           path: coverage/*


### PR DESCRIPTION
## Description

When looking at the results of [a recent GitHub action workflow](https://github.com/nasa/harmony-gdal-adapter/actions/runs/3688257323), I spotted a deprecation warning for the three updated actions. That warning stated we are using versions that depend on Node.js v12, which has been deprecated in favour of v16. This PR makes the necessary updates to those actions (`actions/checkout`, `actions/setup-python` and `actions/upload-artifact`).

## Jira Issue ID

N/A

## Local Test Steps

N/A (we just need to see that the actions run - I'm not sure if the new versions will be used in the PR checks or not - I'll check once this PR kicks them off)

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* ~~`version.txt` and `CHANGE.md` updated if any service code is changed.~~
* ~~Tests added/updated and passing.~~
* ~~Documentation updated (if needed).~~

(This is a CI/CD update only)