### PR TITLE
DAS-1713 - Implement reusable workflow for running Python test suite.

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -11,40 +11,7 @@ env:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ 3.8 ]
-
-    steps:
-      - name: Checkout harmony-gdal-adapter repository
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Build test image
-        run: ./bin/build-test
-
-      - name: Run test image
-        run: ./bin/run-test
-
-      - name: Archive test results
-        uses: actions/upload-artifact@v3
-        with:
-          name: Test results for Python ${{ matrix.python-version }}
-          path: test-reports/
-
-      - name: Archive coverage report
-        uses: actions/upload-artifact@v3
-        with:
-          name: Coverage report for Python ${{ matrix.python-version }}
-          path: coverage/*
+    uses: ./.github/workflows/run_tests.yml
 
   build_and_publish_image:
     needs: run_tests
@@ -62,7 +29,7 @@ jobs:
         run: echo "semantic_version=$(cat version.txt)" >> $GITHUB_ENV
 
       - name: Log-in to ghcr.io registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -70,14 +37,14 @@ jobs:
 
       - name: Add tags to the Docker image
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}},value=${{ env.semantic_version }}
 
       - name: Push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: docker/service.Dockerfile

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,16 +1,13 @@
 name: Run Python unit tests
 
 on:
-  pull_request:
-    branches: [ main ]
+  workflow_call
 
 jobs:
   build_and_test:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
-      matrix:
-        python-version: [ 3.8 ]
 
     steps:
       - name: Checkout harmony-gdal-adapter repository
@@ -21,7 +18,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.10
 
       - name: Build test image
         run: ./bin/build-test

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: 3.9
 
       - name: Build test image
         run: ./bin/build-test

--- a/.github/workflows/run_tests_on_pull_requests.yml
+++ b/.github/workflows/run_tests_on_pull_requests.yml
@@ -1,0 +1,9 @@
+name: Run Python unit tests for pull requests against main
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build_and_test:
+    uses: ./.github/workflows/run_tests.yml


### PR DESCRIPTION
## Description

This PR implements a cool trick discovered during DAS-1713, to have a reusable workflow. That means the job that runs the unit test suite can be defined once and called from both the workflow that runs tests for pull requests as well as the workflow that publishes new Docker images.

## Jira Issue ID

DAS-1713.

## Local Test Steps

N/A - see if the action triggered when this PR is opened runs as expected.

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* ~~`version.txt` and `CHANGE.md` updated if any service code is changed.~~
* ~~Tests added/updated and passing.~~
* ~~Documentation updated (if needed).~~